### PR TITLE
[datetime] Fix to handle dates with invalid time offset

### DIFF
--- a/grimoirelab/toolkit/datetime.py
+++ b/grimoirelab/toolkit/datetime.py
@@ -115,7 +115,7 @@ def str_to_datetime(ts):
         # timezone section because it cannot be parsed,
         # like in 'Wed, 26 Oct 2005 15:20:32 -0100 (GMT+1)'
         # or in 'Thu, 14 Aug 2008 02:07:59 +0200 CEST'.
-        m = re.search(r"^.+?\s+[\+\-]\d{4}(\s+.+)$", ts)
+        m = re.search(r"^.+?\s+[\+\-\d]\d{4}(\s+.+)$", ts)
         if m:
             ts = ts[:m.start(1)]
 
@@ -123,18 +123,19 @@ def str_to_datetime(ts):
             dt = parse_datetime(ts)
         except ValueError as e:
             # Try to remove the timezone, usually it causes
-            # problems. If it doesn't work, raise an exception
-            m = re.search(r"^(.+?)\s+[\+\-]\d+$", ts)
+            # problems.
+            m = re.search(r"^(.+?)\s+[\+\-\d]\d{4}.*$", ts)
 
-            if not m:
-                raise e
+            if m:
+                dt = parse_datetime(m.group(1))
+                logger.warning("Date %s str does not have a valid timezone", ts)
+                logger.warning("Date converted removing timezone info")
+                return dt
 
-            dt = parse_datetime(m.group(1))
-
-            logger.warning("Date %s str does not have a valid timezone", ts)
-            logger.warning("Date converted removing timezone info")
+            raise e
 
         return dt
+
     except ValueError as e:
         raise InvalidDateError(date=str(ts))
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -139,6 +139,18 @@ class TestStrToDatetime(unittest.TestCase):
         self.assertIsInstance(date, datetime.datetime)
         self.assertEqual(date, expected)
 
+        date = str_to_datetime('Tue, 06 Jun 2006 20:50:46 00200 (CEST)')
+        expected = datetime.datetime(2006, 6, 6, 20, 50, 46,
+                                     tzinfo=dateutil.tz.tzutc())
+        self.assertIsInstance(date, datetime.datetime)
+        self.assertEqual(date, expected)
+
+        date = str_to_datetime('Sat, 2 Aug 2008 04:18:59 +0500\x1b[D\x1b[D\x1b[D\x1b[-\x1b[C\x1b[C\x1b[C\x1b[C)')
+        expected = datetime.datetime(2008, 8, 2, 4, 18, 59,
+                                     tzinfo=dateutil.tz.tzutc())
+        self.assertIsInstance(date, datetime.datetime)
+        self.assertEqual(date, expected)
+
         date = str_to_datetime('Thu, 14 Aug 2008 02:07:59 +0200 +0100')
         expected = datetime.datetime(2008, 8, 14, 2, 7, 59,
                                      tzinfo=dateutil.tz.tzoffset(None, 7200))


### PR DESCRIPTION
This PR fixes [issue 203 of perceval repo](https://github.com/grimoirelab/perceval/issues/203).
The error happens on dates with invalid time offset, for instance:

- Tue, 06 Jun 2006 20:50:46 **00200** (CEST) [missing + or -]
- Sat, 2 Aug 2008 04:18:59 **+0500\x1b[D\x1b[...** [encoding problem]

In those cases, time offset and what comes after is stripped off, and the date is converted to UTC