### PR TITLE
Fix tests for Concourse compatibility

### DIFF
--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -20,13 +20,11 @@
 #
 
 import datetime
-import sys
 import unittest
 
 import dateutil
 import pkg_resources
 
-sys.path.insert(0, '..')
 pkg_resources.declare_namespace('grimoirelab.toolkit')
 
 from grimoirelab.toolkit.datetime import (InvalidDateError,

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -19,12 +19,10 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
-import sys
 import unittest
 
 import pkg_resources
 
-sys.path.insert(0, '..')
 pkg_resources.declare_namespace('grimoirelab.toolkit')
 
 from grimoirelab.toolkit.introspect import (inspect_signature_parameters,

--- a/tests/test_uris.py
+++ b/tests/test_uris.py
@@ -19,12 +19,10 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
-import sys
 import unittest
 
 import pkg_resources
 
-sys.path.insert(0, '..')
 pkg_resources.declare_namespace('grimoirelab.toolkit')
 
 from grimoirelab.toolkit.uris import urijoin


### PR DESCRIPTION
By default, Python gets tests from its `PYTHONPATH`. The line which was removed now in each test forced to get tests from the source code directory for developing purposes.

The reason why these lines have been removed is because we are working with Concourse CI tool and we need the tests to execute from the installed directory.