### PR TITLE
[datetime] Add timezone data to datetime_utcnow()

### DIFF
--- a/grimoirelab/toolkit/datetime.py
+++ b/grimoirelab/toolkit/datetime.py
@@ -59,7 +59,7 @@ class InvalidDateError(Exception):
 def datetime_utcnow():
     """Handy function which returns the current date and time in UTC."""
 
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 def datetime_to_utc(ts):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -30,7 +30,8 @@ pkg_resources.declare_namespace('grimoirelab.toolkit')
 from grimoirelab.toolkit.datetime import (InvalidDateError,
                                           datetime_to_utc,
                                           str_to_datetime,
-                                          unixtime_to_datetime)
+                                          unixtime_to_datetime,
+                                          datetime_utcnow)
 
 
 class TestInvalidDateError(unittest.TestCase):
@@ -176,6 +177,15 @@ class TestStrToDatetime(unittest.TestCase):
         self.assertRaises(InvalidDateError, str_to_datetime, 'nodate')
         self.assertRaises(InvalidDateError, str_to_datetime, None)
         self.assertRaises(InvalidDateError, str_to_datetime, '')
+
+    def test_datetime_utcnow(self):
+        """Check whether timezone information is added"""
+
+        now = datetime_utcnow()
+        timezone = str(now.tzinfo)
+        expected = "UTC+00:00"
+
+        self.assertTrue(timezone, expected)
 
 
 class TestUnixTimeToDatetime(unittest.TestCase):


### PR DESCRIPTION
This PR fixes issue #6. It includes timezone information to the current utc time returned by datetime_utcnow(), thus avoiding the creation of a naive datetime instance.