### PR TITLE
[introspect] Ignore * and ** parameters in method signatures

### DIFF
--- a/grimoirelab/toolkit/introspect.py
+++ b/grimoirelab/toolkit/introspect.py
@@ -81,15 +81,21 @@ def find_signature_parameters(callable_, candidates,
                                                     excluded=excluded)
     exec_params = {}
 
+    add_all = False
     for param in signature_params:
         name = param.name
 
-        if name in candidates:
+        if str(param).startswith('*'):
+            add_all = True
+        elif name in candidates:
             exec_params[name] = candidates[name]
         elif param.default == inspect.Parameter.empty:
             msg = "required argument %s not found" % name
             raise AttributeError(msg, name)
         else:
             continue
+
+    if add_all:
+        exec_params = candidates
 
     return exec_params

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -25,6 +25,6 @@ import unittest
 
 
 if __name__ == '__main__':
-    test_suite = unittest.TestLoader().discover('.', pattern='test*.py')
+    test_suite = unittest.TestLoader().discover('.', pattern='test_*.py')
     result = unittest.TextTestRunner(buffer=True).run(test_suite)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -35,6 +35,9 @@ class FakeCallable:
     def __init__(self, *args, **kwargs):
         pass
 
+    def test_args(self, a, **kwargs):
+        pass
+
     def test(self, a, b, c=None):
         pass
 
@@ -115,6 +118,11 @@ class TestFindSignatureParameters(unittest.TestCase):
         """Test if a list of parameters is generated."""
 
         expected = {'a': 1, 'b': 2, 'c': 3}
+        params = {'a': 1, 'b': 2, 'c': 3}
+        found = find_signature_parameters(FakeCallable.test, params)
+        self.assertDictEqual(found, expected)
+
+        expected = {'a': 1, 'b': 2, 'c': 3}
         params = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
         found = find_signature_parameters(FakeCallable.test, params)
         self.assertDictEqual(found, expected)
@@ -122,6 +130,11 @@ class TestFindSignatureParameters(unittest.TestCase):
         expected = {'a': 1, 'b': 2}
         params = {'a': 1, 'b': 2, 'd': 3}
         found = find_signature_parameters(FakeCallable.test, params)
+        self.assertDictEqual(found, expected)
+
+        expected = {'a': 1, 'b': 2}
+        params = {'a': 1, 'b': 2}
+        found = find_signature_parameters(FakeCallable.test_args, params)
         self.assertDictEqual(found, expected)
 
     def test_find_excluding_parameters(self):


### PR DESCRIPTION
This code allows to ignore * and ** parameters of the fetch method in backend.py